### PR TITLE
update to include type of open event in annotationOpen event

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,8 +83,16 @@ plugin.fire('cancelAddingAnnotation');
 ```javascript
 // annotationOpened : Fired whenever an annotation is opened
 plugin.on('annotationOpened', function(event) {
-    var annotationData = event.detail;
-    // do something with annotation data
+    // event.detail =
+    // {
+    //      annotation: (object) annotation data in format {id:.., comments:..., range:..., shape:...},
+    //      triggered_by_timeline: (boolean) TRUE = the event was triggered via a timeline action (like scrubbing or playing), FALSE = the annotation was opened via marker click, UI button interactions, or API/event input
+    // }
+});
+
+// annotationClosed : Fired whenever an annotation is closed
+plugin.on('annotationClosed', function(event) {
+    // event.detail = annotation (object) in format {id:.., comments:..., range:..., shape:...}
 });
 
 // addingAnnotationDataChanged : Fired from adding annotation state if:
@@ -127,7 +135,7 @@ The `gulp templates` task is used to precompile every template within the `/src/
 
 ##### Feature tests
 
-Feature tests are currently browser-based and run by visiting `http://localhost:3004/test/mocha/features/index.html`. Feature tests can be added as files in the `/test/mocha/features/` directory and then included within the `index.html` file as an external script. In the future, running these tests should be automated through phantomJS and a gulp task.
+Feature tests are currently browser-based and run by visiting `http://localhost:3004/mocha/features/index.html`. Feature tests can be added as files in the `/test/mocha/features/` directory and then included within the `index.html` file as an external script. In the future, running these tests should be automated through phantomJS and a gulp task.
 
 ##### Unit tests
 

--- a/src/modules/annotation.js
+++ b/src/modules/annotation.js
@@ -74,6 +74,11 @@ class Annotation extends PlayerComponent {
             this.player.pause();
             this.player.currentTime(this.range.start);
         }
+
+        this.plugin.fire('annotationOpened', {
+            annotation: this.data,
+            triggered_by_timeline: previewOnly
+        });
     }
 
     // Closes the annotation. Handles marker, commendList, shape, and AnnotationState
@@ -83,6 +88,7 @@ class Annotation extends PlayerComponent {
         if(this.annotationShape.$el) this.annotationShape.$el.off("click.annotation");
         this.annotationShape.teardown();
         if(clearActive) this.plugin.annotationState.clearActive();
+        this.plugin.fire('annotationClosed', this.data);
     }
 
     // For preloading an array of seconds active on initialization

--- a/src/modules/annotation_state.js
+++ b/src/modules/annotation_state.js
@@ -163,7 +163,6 @@ class AnnotationState extends PlayerComponent {
 		annotation.open(pause, previewOnly);
 		this.activeAnnotation = annotation;
 		this.lastVideoTime = this.activeAnnotation.range.start;
-		this.plugin.eventDispatcher.fire('annotationOpened', annotation.data);
 	}
 
 	// Finds the next annotation in collection and opens it

--- a/test/mocha/features/api_test.js
+++ b/test/mocha/features/api_test.js
@@ -127,13 +127,14 @@ describe('external event-based API', () => {
         describe('annotationOpened', () => {
             beforeEach(resetVJS);
 
-            it('is triggered when an annotation is opened and includes annotation data', (done) => {
+            it('is triggered when an annotation is opened via click and includes annotation data', (done) => {
                 plugin = simplePluginSetup();
 
                 // Add listener
                 plugin.on('annotationOpened', (event) => {
-                    expect(event.detail.id).to.equal(1);
-                    expect(event.detail.range.end).to.equal(60);
+                    expect(event.detail.triggered_by_timeline).to.equal(false);
+                    expect(event.detail.annotation.id).to.equal(1);
+                    expect(event.detail.annotation.range.end).to.equal(60);
 
                     // remove this listener to play nicely with other tests
                     plugin.off('annotationOpened');
@@ -148,6 +149,29 @@ describe('external event-based API', () => {
                     });
                 });
             });
+
+            it('is triggered when an annotation is opened via timeline and includes annotation data', (done) => {
+                plugin = simplePluginSetup();
+
+                // Add listener
+                plugin.on('annotationOpened', (event) => {
+                    expect(event.detail.triggered_by_timeline).to.equal(true);
+                    expect(event.detail.annotation.id).to.equal(1);
+                    expect(event.detail.annotation.range.end).to.equal(60);
+
+                    // remove this listener to play nicely with other tests
+                    plugin.off('annotationOpened');
+                    done();
+                });
+
+                player.on('loadedmetadata', () => {
+                    player.play().then(() => {
+                        toggleAnnotationMode();
+                        //scrub timeline to where annotation is
+                        player.currentTime(55);
+                    });
+                });
+            }).timeout(4000);
         });
 
         describe('addingAnnotationDataChanged', () => {

--- a/test/test.html
+++ b/test/test.html
@@ -119,7 +119,7 @@
 		<script>
 			var player = window.videojs('the_video');
 			player.on('loadedmetadata', function() {
-				player.annotationComments({
+				var plugin = player.annotationComments({
 					annotationsObjects: annotations,
 					bindArrowKeys: true,
 					meta: {
@@ -132,6 +132,12 @@
 					showFullScreen: true,
 					showMarkerTooltips: true
 				});
+				plugin.on('annotationOpened', (e) => {
+					console.log("annotationOpened", e.detail);
+				});
+				plugin.on('annotationClosed', (e) => {
+					console.log("annotationClosed", e.detail);
+				})
 			});
 		</script>
 	</BODY>


### PR DESCRIPTION
allows event listeners to know how the annotation was being opened and
respond accordingly. Also added an ‘annotationClosed’ event.

contently/contently#13871