### PR TITLE
Exclude test folder when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,3 @@
+node_modules
+docs/.sass-cache
+test


### PR DESCRIPTION
This reduces the package size from 26.5 MB to 864.4 kB  and unpacked size from 29.2 MB to 3.5 MB.